### PR TITLE
Add Timeouts to CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,6 +2,11 @@ name: Build and Test
 
 on:
   workflow_call:
+    inputs:
+      timeout-minutes:
+        required: false
+        type: number
+        default: 15
 
 jobs:
   run:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,11 @@ name: E2E Tests
 
 on:
   workflow_call:
+    inputs:
+      timeout-minutes:
+        required: false
+        type: number
+        default: 30
 
 jobs:
   run:

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -2,6 +2,11 @@ name: Cleanup PR Preview
 
 on:
   workflow_call:
+    inputs:
+      timeout-minutes:
+        required: false
+        type: number
+        default: 5
 
 jobs:
   cleanup:

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -2,6 +2,11 @@ name: Deploy PR Preview
 
 on:
   workflow_call:
+    inputs:
+      timeout-minutes:
+        required: false
+        type: number
+        default: 5
 
 jobs:
   deploy:


### PR DESCRIPTION
🚀 Add default timeout minutes to workflow_call inputs for deploy, build-test, pr-preview-cleanup, and e2e